### PR TITLE
feat: do variable subsitution for servers wherever they are found

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -407,18 +407,18 @@ const getPayloads = function (openApi, path, method) {
  * @return {string}         Base URL
  */
 const getBaseUrl = function (openApi, path, method) {
-  if (openApi.paths[path][method].servers)
-    return openApi.paths[path][method].servers[0].url;
-  if (openApi.paths[path].servers) return openApi.paths[path].servers[0].url;
+  if (openApi.paths[path][method].servers && openApi.paths[path][method].servers.length > 0) {
+    const servers = openApi.paths[path][method].servers
+    return getAServerUrlWithExpandedVariables(servers);
+  }
+  if (openApi.paths[path].servers && openApi.paths[path].servers.length > 0) {
+    const servers = openApi.paths[path].servers;
+    return getAServerUrlWithExpandedVariables(servers);
+  }
 
   if (openApi.servers && openApi.servers.length > 0) {
-    let firstServer = openApi.servers[0];
-    let url = firstServer.url;
-    const variables = firstServer.variables || {};
-    Object.keys(variables).forEach((variable) => {
-      url = url.replace(`{${variable}}`, variables[variable].default);
-    });
-    return url;
+    const servers = openApi.servers;
+    return getAServerUrlWithExpandedVariables(servers);
   }
 
   if (openApi.servers) return openApi.servers[0].url;
@@ -803,6 +803,22 @@ const getHeadersArray = function (openApi, path, method) {
 
   return headers;
 };
+
+/**
+ * Given a non-empty array of Server objects, pick one, expand the variables in its
+ * url and return that url.
+ * @param {array} servers
+ * @returns
+ */
+function getAServerUrlWithExpandedVariables(servers) {
+  let firstServer = servers[0];
+  let url = firstServer.url;
+  const variables = firstServer.variables || {};
+  Object.keys(variables).forEach((variable) => {
+    url = url.replace(`{${variable}}`, variables[variable].default);
+  });
+  return url;
+}
 
 /**
  * Produces array of HAR files for given OpenAPI document

--- a/test/form_data_example.json
+++ b/test/form_data_example.json
@@ -26,6 +26,48 @@
     }
   ],
   "paths": {
+    "/about": {
+      "servers": [
+        {
+          "url": "http://{hostname}/api",
+          "variables": {
+            "hostname": {
+              "default": "example.com"
+            }
+          }
+        }
+      ],
+      "get": {
+        "description": "Get About Info",
+        "operationId": "getAboutInfo",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/about2": {
+      "get": {
+        "description": "Get About Info",
+        "operationId": "getAboutInfo",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "servers": [
+          {
+            "url": "http://{hostname}/api",
+            "variables": {
+              "hostname": {
+                "default": "otherexample.com"
+              }
+            }
+          }
+        ]
+      }
+    },
     "/pets": {
       "patch": {
         "description": "Creates a new pet in the store.  Duplicates are allowed",

--- a/test/test.js
+++ b/test/test.js
@@ -247,6 +247,37 @@ test('If a server has url with variables those should be substituted', function 
   t.end();
 });
 
+test('If a path has servers with variables those should be substituted', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    FormDataExampleReferenceAPI,
+    '/about',
+    'get',
+    ['csharp_restsharp']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(
+    /new RestClient\("http:\/\/example.com\/api\/about"/.test(snippet)
+  );
+  t.false(/{hostname}/.test(snippet));
+  t.end();
+});
+
+test('If an operation has servers with variables those should be substituted', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    FormDataExampleReferenceAPI,
+    '/about2',
+    'get',
+    ['csharp_restsharp']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(
+    /new RestClient\("http:\/\/otherexample.com\/api\/about2"/.test(snippet)
+  );
+  t.false(/{hostname}/.test(snippet));
+  t.end();
+});
+
+
 test('Generate snippet with multipart/form-data with array', function (t) {
   const result = OpenAPISnippets.getEndpointSnippets(
     FormDataExampleReferenceAPI,


### PR DESCRIPTION
In a previous commit we added support for variable substitution for servers found at the root node. Now we support it at the path and operation level as well.