### PR TITLE
chore: update httpsnippet to jci specific version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [24]
 
     steps:
     - name: Checkout repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "openapi-snippet",
-  "version": "0.14.0-jci3",
+  "version": "0.14.0-jci5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-snippet",
-      "version": "0.14.0-jci3",
+      "version": "0.14.0-jci5",
       "license": "MIT",
       "dependencies": {
-        "httpsnippet": "^3.0.9",
+        "httpsnippet": "git+https://github.com/jci-metasys/httpsnippet.git#v3.0.9-jci1",
         "openapi-sampler": "^1.6.1"
       },
       "devDependencies": {
@@ -1692,8 +1692,7 @@
     },
     "node_modules/httpsnippet": {
       "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-3.0.9.tgz",
-      "integrity": "sha512-d5GazgvgT+xd+oltAVJPe+s62mJ5DKGw7yF7Put1fimLc5KwPzbH8Ef/AOMTUwOBSeS3iDqyt9wgYHm+Jyh0CA==",
+      "resolved": "git+ssh://git@github.com/jci-metasys/httpsnippet.git#5826fe98f6f061c5bd87e5ba684f7c71a667a8d8",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -1707,7 +1706,7 @@
         "httpsnippet": "bin/httpsnippet"
       },
       "engines": {
-        "node": "^14.19.1 || ^16.14.2 || ^18.0.0 || ^20.0.0"
+        "node": "^14.19.1 || ^16.14.2 || ^18.0.0 || ^20.0.0 || ^24.0.0"
       }
     },
     "node_modules/httpsnippet/node_modules/ansi-styles": {
@@ -5359,9 +5358,8 @@
       "dev": true
     },
     "httpsnippet": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-3.0.9.tgz",
-      "integrity": "sha512-d5GazgvgT+xd+oltAVJPe+s62mJ5DKGw7yF7Put1fimLc5KwPzbH8Ef/AOMTUwOBSeS3iDqyt9wgYHm+Jyh0CA==",
+      "version": "git+ssh://git@github.com/jci-metasys/httpsnippet.git#5826fe98f6f061c5bd87e5ba684f7c71a667a8d8",
+      "from": "httpsnippet@git+https://github.com/jci-metasys/httpsnippet.git#v3.0.9-jci1",
       "requires": {
         "chalk": "^4.1.2",
         "event-stream": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js"
   },
   "dependencies": {
-    "httpsnippet": "^3.0.9",
+    "httpsnippet": "git+https://github.com/jci-metasys/httpsnippet.git#v3.0.9-jci1",
     "openapi-sampler": "^1.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "test": "node test/test.js | tap-spec",
     "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js"
+    "postinstall": "cd node_modules/httpsnippet && npm install && npm run build"
   },
   "dependencies": {
     "httpsnippet": "git+https://github.com/jci-metasys/httpsnippet.git#v3.0.9-jci1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node test/test.js | tap-spec",
-    "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js"
+    "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js",
     "postinstall": "cd node_modules/httpsnippet && npm install && npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
In this PR I'm updating httpsnippet to use a JCI specific version. This is needed since the previous httpsnippet restricted the node versions to a max of node 20.